### PR TITLE
Set a priority for the qTranslate format function

### DIFF
--- a/modules/acf/src/acf_5/acf.php
+++ b/modules/acf/src/acf_5/acf.php
@@ -18,8 +18,8 @@ class acf_qtranslate_acf_5 implements acf_qtranslate_acf_interface {
 	public function __construct( $plugin ) {
 		$this->plugin = $plugin;
 
-		add_filter( 'acf/format_value', array( $this, 'format_value' ) );
-		add_action( 'acf/include_fields', array( $this, 'include_fields' ) );
+		add_filter( 'acf/format_value', array( $this, 'format_value' ), 5 );
+		add_action( 'acf/include_fields', array( $this, 'include_fields' ), 5 );
 		add_action( 'acf/input/admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 	}
 


### PR DESCRIPTION
So it avoids a problem when using translatable fields on admin (ACF options page)
If not, priority 10 is going to be automatically assigned and fields will return empty.